### PR TITLE
Add sync bounds and flush on Builder::finish

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -122,7 +122,7 @@ impl<W: Write + Unpin + Send + 'static> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append<R: Read + Unpin>(
+    pub async fn append<R: Read + Unpin + Send>(
         &mut self,
         header: &Header,
         mut data: R,
@@ -176,7 +176,7 @@ impl<W: Write + Unpin + Send + 'static> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin>(
+    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin + Send>(
         &mut self,
         header: &mut Header,
         path: P,
@@ -412,9 +412,9 @@ impl<W: Write + Unpin + Send + 'static> Builder<W> {
 }
 
 async fn append(
-    mut dst: &mut (dyn Write + Unpin),
+    mut dst: &mut (dyn Write + Unpin + Send),
     header: &Header,
-    mut data: &mut (dyn Read + Unpin),
+    mut data: &mut (dyn Read + Unpin + Send),
 ) -> io::Result<()> {
     dst.write_all(header.as_bytes()).await?;
     let len = io::copy(&mut data, &mut dst).await?;
@@ -430,7 +430,7 @@ async fn append(
 }
 
 async fn append_path_with_name(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     path: &Path,
     name: Option<&Path>,
     mode: HeaderMode,
@@ -484,7 +484,7 @@ async fn append_path_with_name(
 }
 
 async fn append_file(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     path: &Path,
     file: &mut fs::File,
     mode: HeaderMode,
@@ -495,7 +495,7 @@ async fn append_file(
 }
 
 async fn append_dir(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     path: &Path,
     src_path: &Path,
     mode: HeaderMode,
@@ -521,7 +521,7 @@ fn prepare_header(size: u64, entry_type: EntryType) -> Header {
 }
 
 async fn prepare_header_path(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     header: &mut Header,
     path: &Path,
 ) -> io::Result<()> {
@@ -550,7 +550,7 @@ async fn prepare_header_path(
 }
 
 async fn prepare_header_link(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     header: &mut Header,
     link_name: &Path,
 ) -> io::Result<()> {
@@ -568,10 +568,10 @@ async fn prepare_header_link(
 }
 
 async fn append_fs(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     path: &Path,
     meta: &Metadata,
-    read: &mut (dyn Read + Unpin),
+    read: &mut (dyn Read + Unpin + Send),
     mode: HeaderMode,
     link_name: Option<&Path>,
 ) -> io::Result<()> {
@@ -589,7 +589,7 @@ async fn append_fs(
 }
 
 async fn append_dir_all(
-    dst: &mut (dyn Write + Unpin),
+    dst: &mut (dyn Write + Unpin + Send),
     path: &Path,
     src_path: &Path,
     mode: HeaderMode,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -407,6 +407,7 @@ impl<W: Write + Unpin + Send + 'static> Builder<W> {
         }
         self.finished = true;
         self.get_mut().write_all(&[0; 1024]).await?;
+        self.get_mut().flush().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
These changes allow building an archive and spawning the "builder future".