### PR TITLE
archive: relax Sync constraint on the reader

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -131,7 +131,7 @@ impl<R: Read + Unpin> ArchiveBuilder<R> {
     }
 }
 
-impl<R: Read + Unpin + Sync + Send> Archive<R> {
+impl<R: Read + Unpin + Send> Archive<R> {
     /// Create a new archive with the underlying object as the reader.
     pub fn new(obj: R) -> Archive<R> {
         Archive {


### PR DESCRIPTION
The reader is wrapper into a Mutex so there is not point requiring it to
be Sync itself.