### PR TITLE
Remove println for debugging in `EntryFields.unpack_in`

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -467,7 +467,6 @@ impl<R: Read + Unpin> EntryFields<R> {
         };
 
         if parent.symlink_metadata().is_err() {
-            println!("create_dir_all {:?}", parent);
             fs::create_dir_all(&parent).await.map_err(|e| {
                 TarError::new(&format!("failed to create `{}`", parent.display()), e)
             })?;


### PR DESCRIPTION
It seems like you (accidentally?) added a `println` statement when a directory has to be created for unpacking. Removed it.