### PR TITLE
Remove `Send + Sync` bounds

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -131,7 +131,7 @@ impl<R: Read + Unpin> ArchiveBuilder<R> {
     }
 }
 
-impl<R: Read + Unpin + Sync + Send> Archive<R> {
+impl<R: Read + Unpin> Archive<R> {
     /// Create a new archive with the underlying object as the reader.
     pub fn new(obj: R) -> Archive<R> {
         Archive {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -72,7 +72,7 @@ async fn simple_concat() {
 
     async fn decode_names<R>(ar: &mut Archive<R>) -> Vec<String>
     where
-        R: AsyncRead + Unpin + Sync + Send,
+        R: AsyncRead + Unpin,
     {
         let mut names = Vec::new();
         let mut entries = t!(ar.entries());


### PR DESCRIPTION
The original `tar` crate imposes no such requirement.  And neither
does `async_tar`: https://docs.rs/async-tar/0.4.2/src/async_tar/archive.rs.html#27

In most cases in our test code we're working with owned values,
which will meet these bounds.

But I'm working on a library which does some dynamic computation of e.g.
compression or other things, and I don't want to impose `Send + Sync`
bounds across everything up the stack there.