### PR TITLE
Fix 1.66 clippy lints

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -182,7 +182,7 @@ impl<W: Write + Unpin + Send + 'static> Builder<W> {
     ) -> io::Result<()> {
         prepare_header_path(self.get_mut(), header, path.as_ref()).await?;
         header.set_cksum();
-        self.append(&header, data).await?;
+        self.append(header, data).await?;
 
         Ok(())
     }
@@ -528,7 +528,7 @@ async fn prepare_header_path<Dst: Write + Unpin + ?Sized>(
     // long name extension by emitting an entry which indicates that it's the
     // filename.
     if let Err(e) = header.set_path(path) {
-        let data = path2bytes(&path)?;
+        let data = path2bytes(path)?;
         let max = header.as_old().name.len();
         //  Since e isn't specific enough to let us know the path is indeed too
         //  long, verify it first before using the extension.
@@ -553,8 +553,8 @@ async fn prepare_header_link<Dst: Write + Unpin + ?Sized>(
     link_name: &Path,
 ) -> io::Result<()> {
     // Same as previous function but for linkname
-    if let Err(e) = header.set_link_name(&link_name) {
-        let data = path2bytes(&link_name)?;
+    if let Err(e) = header.set_link_name(link_name) {
+        let data = path2bytes(link_name)?;
         if data.len() < header.as_old().linkname.len() {
             return Err(e);
         }
@@ -595,7 +595,7 @@ async fn append_dir_all<Dst: Write + Unpin + ?Sized>(
 ) -> io::Result<()> {
     let mut stack = vec![(src_path.to_path_buf(), true, false)];
     while let Some((src, is_dir, is_symlink)) = stack.pop() {
-        let dest = path.join(src.strip_prefix(&src_path).unwrap());
+        let dest = path.join(src.strip_prefix(src_path).unwrap());
 
         // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
         if is_dir || (is_symlink && follow && src.is_dir()) {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -472,7 +472,7 @@ impl<R: Read + Unpin> EntryFields<R> {
             })?;
         }
 
-        let canon_target = self.validate_inside_dst(&dst, parent).await?;
+        let canon_target = self.validate_inside_dst(dst, parent).await?;
 
         self.unpack(Some(&canon_target), &file_dst)
             .await
@@ -542,7 +542,7 @@ impl<R: Read + Unpin> EntryFields<R> {
                     // use canonicalization to ensure this guarantee. For hard
                     // links though they're canonicalized to their existing path
                     // so we need to validate at this time.
-                    Some(ref p) => {
+                    Some(p) => {
                         let link_src = p.join(src);
                         self.validate_inside_dst(p, &link_src).await?;
                         link_src
@@ -680,7 +680,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         if self.preserve_mtime {
             if let Ok(mtime) = self.header.mtime() {
                 let mtime = FileTime::from_unix_time(mtime as i64, 0);
-                filetime::set_file_times(&dst, mtime, mtime).map_err(|e| {
+                filetime::set_file_times(dst, mtime, mtime).map_err(|e| {
                     TarError::new(&format!("failed to set mtime for `{}`", dst.display()), e)
                 })?;
             }

--- a/src/header.rs
+++ b/src/header.rs
@@ -446,14 +446,12 @@ impl Header {
     ///
     /// May return an error if the field is corrupted.
     pub fn uid(&self) -> io::Result<u64> {
-        num_field_wrapper_from(&self.as_old().uid)
-            .map(|u| u as u64)
-            .map_err(|err| {
-                io::Error::new(
-                    err.kind(),
-                    format!("{} when getting uid for {}", err, self.path_lossy()),
-                )
-            })
+        num_field_wrapper_from(&self.as_old().uid).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when getting uid for {}", err, self.path_lossy()),
+            )
+        })
     }
 
     /// Encodes the `uid` provided into this header.
@@ -463,14 +461,12 @@ impl Header {
 
     /// Returns the value of the group's user ID field
     pub fn gid(&self) -> io::Result<u64> {
-        num_field_wrapper_from(&self.as_old().gid)
-            .map(|u| u as u64)
-            .map_err(|err| {
-                io::Error::new(
-                    err.kind(),
-                    format!("{} when getting gid for {}", err, self.path_lossy()),
-                )
-            })
+        num_field_wrapper_from(&self.as_old().gid).map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!("{} when getting gid for {}", err, self.path_lossy()),
+            )
+        })
     }
 
     /// Encodes the `gid` provided into this header.
@@ -723,7 +719,7 @@ impl Header {
                 self.set_mtime(meta.mtime() as u64);
                 self.set_uid(meta.uid() as u64);
                 self.set_gid(meta.gid() as u64);
-                self.set_mode(meta.mode() as u32);
+                self.set_mode(meta.mode());
             }
             HeaderMode::Deterministic => {
                 self.set_mtime(0);
@@ -1106,8 +1102,8 @@ impl GnuHeader {
     fn fullname_lossy(&self) -> String {
         format!(
             "{}:{}",
-            String::from_utf8_lossy(&self.groupname_bytes()),
-            String::from_utf8_lossy(&self.username_bytes()),
+            String::from_utf8_lossy(self.groupname_bytes()),
+            String::from_utf8_lossy(self.username_bytes()),
         )
     }
 
@@ -1504,7 +1500,7 @@ fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::R
                 return Err(other("path component in archive cannot contain `/`"));
             }
         }
-        copy(&mut slot, &*bytes)?;
+        copy(&mut slot, &bytes)?;
         if &*bytes != b"/" {
             needs_slash = true;
         }
@@ -1519,8 +1515,8 @@ fn copy_path_into(mut slot: &mut [u8], path: &Path, is_link_name: bool) -> io::R
     return Ok(());
 
     fn copy(slot: &mut &mut [u8], bytes: &[u8]) -> io::Result<()> {
-        copy_into(*slot, bytes)?;
-        let tmp = mem::replace(slot, &mut []);
+        copy_into(slot, bytes)?;
+        let tmp = mem::take(slot);
         *slot = &mut tmp[bytes.len()..];
         Ok(())
     }


### PR DESCRIPTION
One more left unfixed:
```
    Checking tokio-tar v0.3.0 (/Users/someonetoignore/work/other/tokio-tar)
error: calls to `std::mem::drop` with a reference instead of an owned value. Dropping a reference does nothing
   --> src/archive.rs:429:5
    |
429 |     drop(header);
    |     ^^^^^^^^^^^^
    |
note: argument has type `&mut header::Header`
   --> src/archive.rs:429:10
    |
429 |     drop(header);
    |          ^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_ref
    = note: `#[deny(clippy::drop_ref)]` on by default
```