### PR TITLE
Fix next archive header position

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -368,7 +368,7 @@ fn poll_next_raw<R: Read + Unpin>(
     loop {
         // Seek to the start of the next header in the archive
         if current_header.is_none() {
-            let delta = *next - archive.inner.pos.load(Ordering::SeqCst);
+            let Some(delta) = next.checked_sub(archive.inner.pos.load(Ordering::SeqCst)) else { return Poll::Ready(None) };
             match futures_core::ready!(poll_skip(&mut archive, cx, delta)) {
                 Ok(_) => {}
                 Err(err) => return Poll::Ready(Some(Err(err))),


### PR DESCRIPTION
My use case of `tokio-tar` is to transfer files/folder over the network using TCP :
1. The sender machine send files/folders using `TcpStream` from `tokio`.
2. The receiver machine receives files/folders using `TcpListener` from `tokio`.

As indicated to the documentation, reading the archive when appending files/folders corrupts it (which basically panic).

So this PR aims to mitigate that behaviour by catching the panic and handle it properly.