### PR TITLE
Fix docstring test, in case cwd is not available

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -395,9 +395,11 @@ impl<W: Write + Unpin + Send> Builder<W> {
     ///
     /// let mut ar = Builder::new(Vec::new());
     ///
+    /// let td = tempfile::tempdir()?;
+    ///
     /// // Use the directory at one location, but insert it into the archive
     /// // with a different name.
-    /// ar.append_dir_all("bardir", ".").await?;
+    /// ar.append_dir_all("bardir", td.path()).await?;
     /// #
     /// # Ok(()) }) }
     /// ```


### PR DESCRIPTION
Running "cargo test", this fails for me with:

```
---- src/builder.rs - builder::Builder<W>::append_dir_all (line 390) stdout ----
Test executable failed (exit status: 1).

stderr:
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```