### PR TITLE
Include tar archives in crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT/Apache-2.0"
 keywords = ["tar", "tarfile", "encoding"]
 readme = "README.md"
 edition = "2018"
-exclude = ["tests/archives/*"]
 
 description = """
 A Rust implementation of an async TAR file reader and writer. This library does not


### PR DESCRIPTION
When packaging this crate for Debian I noticed the crates.io release does not include the tar archives needed to run the tests. Please consider including them